### PR TITLE
fix: update vite to have module-runner export available

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "@vitest/coverage-istanbul": "latest",
     "@vitest/coverage-v8": "latest",
     "typescript": "^5.2.2",
-    "vite": "^5.4.10",
+    "vite": "^8.0.1",
     "vitest": "latest"
   }
 }


### PR DESCRIPTION
Fixes ecosystem CI errors

```
  Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './module-runner' is not defined by "exports" in /home/runner/work/vitest-ecosystem-ci/vitest-ecosystem-ci/workspace/vitest-coverage-large/coverage-large/node_modules/.pnpm/file+..+..+vitest+packages+vitest+vitest-4.1.0.tgz_@types+node@20.19.37_@vitest+browser-playw_lmbb3bktfmihpnrg2c2hdslubi/node_modules/vite/package.json imported from /home/runner/work/vitest-ecosystem-ci/vitest-ecosystem-ci/workspace/vitest-coverage-large/coverage-large/node_modules/.pnpm/file+..+..+vitest+packages+vitest+vitest-4.1.0.tgz_@types+node@20.19.37_@vitest+browser-playw_lmbb3bktfmihpnrg2c2hdslubi/node_modules/vitest/dist/chunks/cli-api.BLF7mjQE.js
```
